### PR TITLE
Add 404 status code when no route is matching the URL pattern

### DIFF
--- a/src/MetaRouter.php
+++ b/src/MetaRouter.php
@@ -69,7 +69,7 @@ class MetaRouter extends AbstractMiddleware
         
         if(is_null($matchedRoute))
         {
-            throw new Exception('Unable to route request: no route matched requested URL');
+            throw new Exception('Unable to route request: no route matched requested URL', 404);
         }
         
         $app->getRequest()->setMatchedRoute($matchedRoute);


### PR DESCRIPTION
I've added the status code in the MetaRouter class. Vincent is rewriting the ExceptionHandler that will use this status code.