### PR TITLE
PSR-7 requests routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,5 +38,28 @@ A ```RoutingResult``` that did match is able to return a ```MatchedRoute``` inst
 ## Performance
 
 Using several routers can help dealing with performance issue, since it allows to use advanced routes when needed only. Please note that the later a Router is registered, the higher is its priority in the routing loop.
- 
+
+## Usage
+### Standalone
+```php
+use GuzzleHttp\Psr7\ServerRequest;
+use ObjectivePHP\Package\FastRoute\FastRouteRouter;
+use ObjectivePHP\Router\MetaRouter;
+
+
+// Create the main MetaRouter
+$metaRouter = new MetaRouter();
+
+// Register the routers
+$metaRouter->register(new FastRouteRouter());
+
+// Route the request to get the RoutingResult
+$result = $metaRouter->routeRequest(ServerRequest::fromGlobals());
+
+// You can render your action
+echo $result->getMatchedRoute()->getAction()();
+
+// Or, if you want to use it in an Objective PHP application
+$app->getRequest()->setMatchedRoute($result->getMatchedRoute());
+```
  

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
   ],
   "require": {
     "php": ">=7.0",
-    "objective-php/phpunit-extension": "~1.0"
+    "objective-php/phpunit-extension": "~1.0",
+    "psr/http-message": "^1.0"
   },
   "require-dev": {
     "phpunit/phpunit": "5.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "fcd3371a420964fe646a20d06a28cc62",
-    "content-hash": "0c16a07952ffe3cbb400eaebf15b6752",
+    "content-hash": "a31bf80c447d4931f5ae0fb3bce2aa51",
     "packages": [
         {
             "name": "objective-php/phpunit-extension",
@@ -50,7 +49,57 @@
                 "objective php",
                 "phpunit"
             ],
-            "time": "2016-05-05 12:55:53"
+            "time": "2016-05-05T12:55:53+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2016-08-06T14:39:51+00:00"
         }
     ],
     "packages-dev": [
@@ -79,7 +128,7 @@
                 "MIT"
             ],
             "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
-            "time": "2014-12-30 15:22:37"
+            "time": "2014-12-30T15:22:37+00:00"
         },
         {
             "name": "doctrine/annotations",
@@ -147,7 +196,7 @@
                 "docblock",
                 "parser"
             ],
-            "time": "2015-08-31 12:32:49"
+            "time": "2015-08-31T12:32:49+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -201,7 +250,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14 21:17:01"
+            "time": "2015-06-14T21:17:01+00:00"
         },
         {
             "name": "doctrine/lexer",
@@ -255,7 +304,7 @@
                 "lexer",
                 "parser"
             ],
-            "time": "2014-09-09 13:34:57"
+            "time": "2014-09-09T13:34:57+00:00"
         },
         {
             "name": "erusev/parsedown",
@@ -294,7 +343,7 @@
                 "markdown",
                 "parser"
             ],
-            "time": "2015-10-04 16:44:32"
+            "time": "2015-10-04T16:44:32+00:00"
         },
         {
             "name": "erusev/parsedown-extra",
@@ -338,7 +387,7 @@
                 "parsedown",
                 "parser"
             ],
-            "time": "2015-11-01 10:19:22"
+            "time": "2015-11-01T10:19:22+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -380,7 +429,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2015-11-20 12:04:31"
+            "time": "2015-11-20T12:04:31+00:00"
         },
         {
             "name": "objective-php/application",
@@ -479,7 +528,7 @@
                 "objective php",
                 "primitives"
             ],
-            "time": "2016-05-05 15:59:19"
+            "time": "2016-05-05T15:59:19+00:00"
         },
         {
             "name": "objective-php/config",
@@ -527,7 +576,7 @@
                 "config",
                 "objective-php"
             ],
-            "time": "2016-05-08 09:15:05"
+            "time": "2016-05-08T09:15:05+00:00"
         },
         {
             "name": "objective-php/data-processor",
@@ -579,7 +628,7 @@
                 "data procesosr",
                 "objective php"
             ],
-            "time": "2016-05-05 15:32:33"
+            "time": "2016-05-05T15:32:33+00:00"
         },
         {
             "name": "objective-php/events-handler",
@@ -628,7 +677,7 @@
                 "events handler",
                 "objective php"
             ],
-            "time": "2016-05-06 15:58:36"
+            "time": "2016-05-06T15:58:36+00:00"
         },
         {
             "name": "objective-php/html",
@@ -676,7 +725,7 @@
                 "html",
                 "objective php"
             ],
-            "time": "2016-05-06 22:22:14"
+            "time": "2016-05-06T22:22:14+00:00"
         },
         {
             "name": "objective-php/invokable",
@@ -724,7 +773,7 @@
                 "invokable",
                 "objective php"
             ],
-            "time": "2016-05-06 16:10:35"
+            "time": "2016-05-06T16:10:35+00:00"
         },
         {
             "name": "objective-php/matcher",
@@ -770,7 +819,7 @@
                 "matcher",
                 "objective php"
             ],
-            "time": "2016-05-05 13:13:34"
+            "time": "2016-05-05T13:13:34+00:00"
         },
         {
             "name": "objective-php/message",
@@ -811,7 +860,7 @@
                 }
             ],
             "description": "ObjectivePHP implementation for PSR-7",
-            "time": "2016-05-05 14:33:38"
+            "time": "2016-05-05T14:33:38+00:00"
         },
         {
             "name": "objective-php/notification",
@@ -864,7 +913,7 @@
                 "components",
                 "objective php"
             ],
-            "time": "2016-05-05 14:02:15"
+            "time": "2016-05-05T14:02:15+00:00"
         },
         {
             "name": "objective-php/primitives",
@@ -918,7 +967,7 @@
                 "objective php",
                 "primitives"
             ],
-            "time": "2016-05-12 14:56:23"
+            "time": "2016-05-12T14:56:23+00:00"
         },
         {
             "name": "objective-php/services-factory",
@@ -973,7 +1022,7 @@
                 "objective php",
                 "services"
             ],
-            "time": "2016-05-08 13:28:26"
+            "time": "2016-05-08T13:28:26+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -1022,7 +1071,7 @@
                     "email": "mike.vanriel@naenius.com"
                 }
             ],
-            "time": "2015-02-03 12:10:50"
+            "time": "2015-02-03T12:10:50+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -1084,7 +1133,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2016-02-15 07:46:21"
+            "time": "2016-02-15T07:46:21+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1147,7 +1196,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-05-27 16:24:29"
+            "time": "2016-05-27T16:24:29+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1194,7 +1243,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2015-06-21 13:08:43"
+            "time": "2015-06-21T13:08:43+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -1235,7 +1284,7 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21 13:50:34"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -1279,7 +1328,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2016-05-12 18:03:57"
+            "time": "2016-05-12T18:03:57+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -1328,7 +1377,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2015-09-15 10:49:45"
+            "time": "2015-09-15T10:49:45+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -1403,7 +1452,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-05-11 13:28:45"
+            "time": "2016-05-11T13:28:45+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -1459,56 +1508,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2016-04-20 14:39:26"
-        },
-        {
-            "name": "psr/http-message",
-            "version": "1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/http-message.git",
-                "reference": "85d63699f0dbedb190bbd4b0d2b9dc707ea4c298"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-message/zipball/85d63699f0dbedb190bbd4b0d2b9dc707ea4c298",
-                "reference": "85d63699f0dbedb190bbd4b0d2b9dc707ea4c298",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Http\\Message\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for HTTP messages",
-            "keywords": [
-                "http",
-                "http-message",
-                "psr",
-                "psr-7",
-                "request",
-                "response"
-            ],
-            "time": "2015-05-04 20:22:00"
+            "time": "2016-04-20T14:39:26+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -1553,7 +1553,7 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "time": "2016-02-13 06:45:14"
+            "time": "2016-02-13T06:45:14+00:00"
         },
         {
             "name": "sebastian/comparator",
@@ -1617,7 +1617,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2015-07-26 15:48:44"
+            "time": "2015-07-26T15:48:44+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -1669,7 +1669,7 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2015-12-08 07:14:41"
+            "time": "2015-12-08T07:14:41+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -1719,7 +1719,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-05-17 03:18:57"
+            "time": "2016-05-17T03:18:57+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -1785,7 +1785,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2015-06-21 07:55:53"
+            "time": "2015-06-21T07:55:53+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -1836,7 +1836,7 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12 03:26:01"
+            "time": "2015-10-12T03:26:01+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -1882,7 +1882,7 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2016-01-28 13:25:10"
+            "time": "2016-01-28T13:25:10+00:00"
         },
         {
             "name": "sebastian/recursion-context",
@@ -1935,7 +1935,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-11-11 19:50:13"
+            "time": "2015-11-11T19:50:13+00:00"
         },
         {
             "name": "sebastian/resource-operations",
@@ -1977,7 +1977,7 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2015-07-28 20:34:47"
+            "time": "2015-07-28T20:34:47+00:00"
         },
         {
             "name": "sebastian/version",
@@ -2020,7 +2020,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2016-02-04 12:56:52"
+            "time": "2016-02-04T12:56:52+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -2069,7 +2069,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-05-26 21:46:24"
+            "time": "2016-05-26T21:46:24+00:00"
         },
         {
             "name": "zendframework/zend-diactoros",
@@ -2119,7 +2119,7 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2016-03-17 18:02:05"
+            "time": "2016-03-17T18:02:05+00:00"
         }
     ],
     "aliases": [],

--- a/src/MetaRouter.php
+++ b/src/MetaRouter.php
@@ -5,7 +5,7 @@ namespace ObjectivePHP\Router;
 use ObjectivePHP\Application\ApplicationInterface;
 use ObjectivePHP\Application\Middleware\AbstractMiddleware;
 use ObjectivePHP\Primitives\Collection\Collection;
-
+use Psr\Http\Message\RequestInterface;
 
 /**
  * Class MetaRouter
@@ -13,25 +13,29 @@ use ObjectivePHP\Primitives\Collection\Collection;
  */
 class MetaRouter extends AbstractMiddleware
 {
-
     /**
-     * @var Collection
+     * @var Collection $routers
      */
     protected $routers;
 
+    /**
+     * MetaRouter constructor.
+     * @param array $routers
+     */
     public function __construct($routers = [])
     {
-
         $this->routers = Collection::cast($routers);
     }
 
 
     /**
      * @param RouterInterface $router
+     * @return $this
      */
     public function register(RouterInterface $router)
     {
         $this->routers->prepend($router);
+        return $this;
     }
 
     /**
@@ -48,30 +52,55 @@ class MetaRouter extends AbstractMiddleware
      */
     public function run(ApplicationInterface $app)
     {
-        if(!$this->routers)
-        {
+        if (!$this->routers) {
             throw new Exception('Unable to route request: no router has been registered');
         }
 
         $matchedRoute = null;
-        
         /** @var RouterInterface $router */
-        foreach($this->routers as $router) 
-        {
+        foreach ($this->routers as $router) {
             $routingResult = $router->route($app);
-            
-            if($routingResult->didMatch())
-            {
+            if ($routingResult->didMatch()) {
                 $matchedRoute = $routingResult->getMatchedRoute();
                 break;
             }
         }
         
-        if(is_null($matchedRoute))
-        {
-            throw new Exception('Unable to route request: no route matched requested URL', 404);
+        if (is_null($matchedRoute)) {
+            throw new NoRouteFoundException();
         }
         
         $app->getRequest()->setMatchedRoute($matchedRoute);
+    }
+
+    /**
+     * Route a PSR-7 request.
+     *
+     * @param RequestInterface $request
+     * @return RoutingResult
+     * @throws Exception
+     * @throws NoRouteFoundException
+     */
+    public function routeRequest(RequestInterface $request): RoutingResult
+    {
+        if(!$this->routers) {
+            throw new Exception('Unable to route request: no router has been registered');
+        }
+
+        $matchedResult = null;
+        foreach($this->routers as $router) {
+            $routingResult = $router->routeRequest($request);
+
+            if($routingResult->didMatch()) {
+                $matchedResult = $routingResult;
+                break;
+            }
+        }
+
+        if (is_null($matchedResult)) {
+            throw new NoRouteFoundException();
+        }
+
+        return $matchedResult;
     }
 }

--- a/src/NoRouteFoundException.php
+++ b/src/NoRouteFoundException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace ObjectivePHP\Router;
+
+/**
+ * Class NoRouteFoundException
+ * @package ObjectivePHP\Router
+ */
+class NoRouteFoundException extends Exception
+{
+    protected $message = "Unable to route request : no route matched requested URL";
+    protected $code = 404;
+}

--- a/src/PathMapperRouter.php
+++ b/src/PathMapperRouter.php
@@ -6,7 +6,6 @@ use ObjectivePHP\Application\ApplicationInterface;
 use ObjectivePHP\Application\Config\ActionNamespace;
 use ObjectivePHP\Primitives\String\Str;
 use ObjectivePHP\Router\Config\UrlAlias;
-use ObjectivePHP\Router\Config\SimpleRoute;
 
 /**
  * Class PathMapperRouter

--- a/src/RouterInterface.php
+++ b/src/RouterInterface.php
@@ -3,10 +3,14 @@
 namespace ObjectivePHP\Router;
 
 use ObjectivePHP\Application\ApplicationInterface;
+use Psr\Http\Message\RequestInterface;
 
 interface RouterInterface
 {
     public function route(ApplicationInterface $app) : RoutingResult;
+
+    // This is required but it will introduce a BC break
+    //public function routeRequest(RequestInterface $request) : RoutingResult;
 
     public function url($route, $params = []);
 }

--- a/tests/Router/MetaRouterTest.php
+++ b/tests/Router/MetaRouterTest.php
@@ -14,8 +14,10 @@ use ObjectivePHP\PHPUnit\TestCase;
 use ObjectivePHP\Primitives\Collection\Collection;
 use ObjectivePHP\Router\Exception;
 use ObjectivePHP\Router\MetaRouter;
+use ObjectivePHP\Router\NoRouteFoundException;
 use ObjectivePHP\Router\RouterInterface;
 use ObjectivePHP\Router\RoutingResult;
+use Psr\Http\Message\RequestInterface;
 
 class MetaRouterTest extends TestCase
 {
@@ -31,6 +33,13 @@ class MetaRouterTest extends TestCase
         },
             Exception::class
         );
+
+        $this->expectsException(
+            function () use ($metaRouter) {
+                $metaRouter->routeRequest($this->getMock(RequestInterface::class));
+                },
+            Exception::class
+        );
     }
 
     public function testFailsWhenNoRouterMatchesARoute()
@@ -43,6 +52,7 @@ class MetaRouterTest extends TestCase
         $routingResult->method('didMatch')->willReturn(false);
 
         $router->expects($this->once())->method('route')->willReturn($routingResult);
+        $router->expects($this->once())->method('routeRequest')->willReturn($routingResult);
 
         $metaRouter->register($router);
 
@@ -52,6 +62,14 @@ class MetaRouterTest extends TestCase
             $metaRouter->run($this->getMock(ApplicationInterface::class));
         },
             Exception::class, 'no route matched requested URL'
+        );
+
+        $this->expectsException(
+            function () use ($metaRouter) {
+                $metaRouter->routeRequest($this->getMock(RequestInterface::class));
+            },
+            NoRouteFoundException::class,
+            'no route matched requested URL'
         );
     }
 


### PR DESCRIPTION
The purpose is to allow the router to be used outside an Objective PHP application (see README for usage).

NB : to not introduce BC break I didn't update the RouterInterface but an update should be planned. An update is required for the following routers to support this new feature :
- PathMapperRouter
- FastRouteRouter